### PR TITLE
DFG subject mapping

### DIFF
--- a/rdmo_plugins/optionsets/re3data.py
+++ b/rdmo_plugins/optionsets/re3data.py
@@ -42,7 +42,7 @@ class Re3DataProvider(Provider):
         'https://rdmorganiser.github.io/terms/options/research_fields/190': '303 Physical and Theoretical Chemistry',
         'https://rdmorganiser.github.io/terms/options/research_fields/191': '304 Analytical Chemistry, Method Development (Chemistry)',
         'https://rdmorganiser.github.io/terms/options/research_fields/193': '305 Biological Chemistry and Food Chemistry',
-        'https://rdmorganiser.github.io/terms/options/research_fields/194': '306 Polymer Researc',
+        'https://rdmorganiser.github.io/terms/options/research_fields/194': '306 Polymer Research',
         'https://rdmorganiser.github.io/terms/options/research_fields/195': '307 Condensed Matter Physics',
         'https://rdmorganiser.github.io/terms/options/research_fields/196': '308 Optics, Quantum Optics and Physics of Atoms, Molecules and Plasmas',
         'https://rdmorganiser.github.io/terms/options/research_fields/198': '309 Particles, Nuclei and Fields',

--- a/rdmo_plugins/optionsets/re3data.py
+++ b/rdmo_plugins/optionsets/re3data.py
@@ -15,6 +15,7 @@ class Re3DataProvider(Provider):
 
     subject_attribute = 'https://rdmorganiser.github.io/terms/domain/project/research_field/title'
 
+    # create mapping of RDMO research field identifiers to DFG subject areas (Fachkollegien)
     subjects = {
         'https://rdmorganiser.github.io/terms/options/research_fields/169': '101 Ancient Cultures',
         'https://rdmorganiser.github.io/terms/options/research_fields/174': '102 History',


### PR DESCRIPTION
This PR fixes a typo in a DFG subject area, resulting in the re3data query returning an empty result:

- **Current:** https://www.re3data.org/api/beta/repositories?subjects[]=306+Polymer+Researc
- **Fixed:** https://www.re3data.org/api/beta/repositories?subjects[]=306+Polymer+Research

It might be interesting to note that the DFG subject areas have been updated recently (Fall 2019). The mapping contained in this plugin are compliant with the [2016-2019](https://www.dfg.de/download/pdf/dfg_im_profil/gremien/fachkollegien/amtsperiode_2016_2019/fachsystematik_2016-2019_de_grafik.pdf). I am not sure if this might require an update of this mapping in the future. The new list can be found [here](https://www.dfg.de/dfg_profil/gremien/fachkollegien/faecher/index.jsp), however, currently they do not work in the query.
As an example for a change: `Polymer Research` changed its number from 306 to 326.

